### PR TITLE
Change file mode to wb for windows computers

### DIFF
--- a/build/BUILD.py
+++ b/build/BUILD.py
@@ -53,7 +53,7 @@ def main():
 
     print('Writing "titles.csv"')
 
-    with open('../data/titles.csv', 'w') as f:
+    with open('../data/titles.csv', 'wb') as f:
         output = csv.writer(f)
         output.writerow(('title', 'year'))
         for raw_title in interesting_titles:
@@ -69,7 +69,7 @@ def main():
         line = next(lines)
     assert next(lines) == b'==================\n'
 
-    output = csv.writer(open('../data/release_dates.csv', 'w'))
+    output = csv.writer(open('../data/release_dates.csv', 'wb'))
     output.writerow(('title', 'year', 'country', 'date'))
 
     for line in lines:
@@ -100,7 +100,7 @@ def main():
 
     print('Finished writing "release_dates.csv"')
 
-    output = csv.writer(open('../data/cast.csv', 'w'))
+    output = csv.writer(open('../data/cast.csv', 'wb'))
     output.writerow(('title', 'year', 'name', 'type', 'character', 'n'))
 
     for role_type, filename in (


### PR DESCRIPTION
Without write binary mode on windows machine, csv files have an extra newline appended. wb mode should have no effect on Unix machines (https://docs.python.org/2/tutorial/inputoutput.html#reading-and-writing-files)
