### PR TITLE
Updated README.md with conda install directions for jupyter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ needed to download and set up the data set that we used.
 If you have both `conda` and `git` on your system (otherwise, read the
 next section for more detailed instructions):
 
-    $ conda install --yes ipython-notebook matplotlib pandas
+    $ conda install --yes jupyter matplotlib pandas
     $ git clone https://github.com/brandon-rhodes/pycon-pandas-tutorial.git
     $ cd pycon-pandas-tutorial
     $ build/BUILD.sh


### PR DESCRIPTION
Jupyter installation bundles iPython notebook by default:

[Jupyter Installation](http://jupyter.readthedocs.org/en/latest/install.html)
