### PR TITLE
from_csv is deprecated, updating to read_csv

### DIFF
--- a/Exercises-1.ipynb
+++ b/Exercises-1.ipynb
@@ -80,7 +80,7 @@
       "execution_count": 3, 
       "cell_type": "code", 
       "source": [
-        "titles = pd.read_csv('data/titles.csv')\n", 
+        "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n", 
         "titles.head()"
       ], 
       "outputs": [
@@ -148,7 +148,7 @@
       "execution_count": 4, 
       "cell_type": "code", 
       "source": [
-        "cast = pd.read_csv('data/cast.csv')\n", 
+        "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n", 
         "cast.head()"
       ], 
       "outputs": [

--- a/Exercises-1.ipynb
+++ b/Exercises-1.ipynb
@@ -80,7 +80,7 @@
       "execution_count": 3, 
       "cell_type": "code", 
       "source": [
-        "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n", 
+        "titles = pd.read_csv('data/titles.csv')\n", 
         "titles.head()"
       ], 
       "outputs": [
@@ -148,7 +148,7 @@
       "execution_count": 4, 
       "cell_type": "code", 
       "source": [
-        "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n", 
+        "cast = pd.read_csv('data/cast.csv')\n", 
         "cast.head()"
       ], 
       "outputs": [

--- a/Exercises-2.ipynb
+++ b/Exercises-2.ipynb
@@ -80,7 +80,7 @@
       "execution_count": 3, 
       "cell_type": "code", 
       "source": [
-        "titles = pd.read_csv('data/titles.csv')\n", 
+        "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n", 
         "titles.head()"
       ], 
       "outputs": [
@@ -148,7 +148,7 @@
       "execution_count": 4, 
       "cell_type": "code", 
       "source": [
-        "cast = pd.read_csv('data/cast.csv')\n", 
+        "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n", 
         "cast.head()"
       ], 
       "outputs": [

--- a/Exercises-2.ipynb
+++ b/Exercises-2.ipynb
@@ -80,7 +80,7 @@
       "execution_count": 3, 
       "cell_type": "code", 
       "source": [
-        "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n", 
+        "titles = pd.read_csv('data/titles.csv')\n", 
         "titles.head()"
       ], 
       "outputs": [
@@ -148,7 +148,7 @@
       "execution_count": 4, 
       "cell_type": "code", 
       "source": [
-        "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n", 
+        "cast = pd.read_csv('data/cast.csv')\n", 
         "cast.head()"
       ], 
       "outputs": [

--- a/Exercises-3.ipynb
+++ b/Exercises-3.ipynb
@@ -80,7 +80,7 @@
       "execution_count": 3, 
       "cell_type": "code", 
       "source": [
-        "titles = pd.read_csv('data/titles.csv')\n", 
+        "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n", 
         "titles.head()"
       ], 
       "outputs": [
@@ -148,7 +148,7 @@
       "execution_count": 4, 
       "cell_type": "code", 
       "source": [
-        "cast = pd.read_csv('data/cast.csv')\n", 
+        "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n", 
         "cast.head()"
       ], 
       "outputs": [

--- a/Exercises-3.ipynb
+++ b/Exercises-3.ipynb
@@ -80,7 +80,7 @@
       "execution_count": 3, 
       "cell_type": "code", 
       "source": [
-        "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n", 
+        "titles = pd.read_csv('data/titles.csv')\n", 
         "titles.head()"
       ], 
       "outputs": [
@@ -148,7 +148,7 @@
       "execution_count": 4, 
       "cell_type": "code", 
       "source": [
-        "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n", 
+        "cast = pd.read_csv('data/cast.csv')\n", 
         "cast.head()"
       ], 
       "outputs": [

--- a/Exercises-4.ipynb
+++ b/Exercises-4.ipynb
@@ -80,7 +80,7 @@
       "execution_count": 3, 
       "cell_type": "code", 
       "source": [
-        "titles = pd.read_csv('data/titles.csv')\n", 
+        "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n", 
         "titles.head()"
       ], 
       "outputs": [
@@ -148,7 +148,7 @@
       "execution_count": 4, 
       "cell_type": "code", 
       "source": [
-        "cast = pd.read_csv('data/cast.csv')\n", 
+        "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n", 
         "cast.head()"
       ], 
       "outputs": [

--- a/Exercises-4.ipynb
+++ b/Exercises-4.ipynb
@@ -80,7 +80,7 @@
       "execution_count": 3, 
       "cell_type": "code", 
       "source": [
-        "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n", 
+        "titles = pd.read_csv('data/titles.csv')\n", 
         "titles.head()"
       ], 
       "outputs": [
@@ -148,7 +148,7 @@
       "execution_count": 4, 
       "cell_type": "code", 
       "source": [
-        "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n", 
+        "cast = pd.read_csv('data/cast.csv')\n", 
         "cast.head()"
       ], 
       "outputs": [

--- a/Exercises-5.ipynb
+++ b/Exercises-5.ipynb
@@ -80,7 +80,7 @@
       "execution_count": 3, 
       "cell_type": "code", 
       "source": [
-        "cast = pd.read_csv('data/cast.csv')\n", 
+        "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n", 
         "cast.head()"
       ], 
       "outputs": [
@@ -179,7 +179,7 @@
       "execution_count": 4, 
       "cell_type": "code", 
       "source": [
-        "release_dates = pd.read_csv('data/release_dates.csv',\n", 
+        "release_dates = pd.DataFrame.from_csv('data/release_dates.csv', index_col=None,\n", 
         "                                      parse_dates=['date'], infer_datetime_format=True)\n", 
         "release_dates.head()"
       ], 

--- a/Exercises-5.ipynb
+++ b/Exercises-5.ipynb
@@ -80,7 +80,7 @@
       "execution_count": 3, 
       "cell_type": "code", 
       "source": [
-        "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n", 
+        "cast = pd.read_csv('data/cast.csv')\n", 
         "cast.head()"
       ], 
       "outputs": [
@@ -179,7 +179,7 @@
       "execution_count": 4, 
       "cell_type": "code", 
       "source": [
-        "release_dates = pd.DataFrame.from_csv('data/release_dates.csv', index_col=None,\n", 
+        "release_dates = pd.read_csv('data/release_dates.csv',\n", 
         "                                      parse_dates=['date'], infer_datetime_format=True)\n", 
         "release_dates.head()"
       ], 

--- a/Exercises-5.ipynb
+++ b/Exercises-5.ipynb
@@ -80,7 +80,7 @@
       "execution_count": 3, 
       "cell_type": "code", 
       "source": [
-        "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n", 
+        "cast = pd.read_csv('data/cast.csv')\n", 
         "cast.head()"
       ], 
       "outputs": [
@@ -179,7 +179,7 @@
       "execution_count": 4, 
       "cell_type": "code", 
       "source": [
-        "release_dates = pd.DataFrame.from_csv('data/release_dates.csv', index_col=None,\n", 
+        "release_dates = pd.read_csv('data/release_dates.csv', \n", 
         "                                      parse_dates=['date'], infer_datetime_format=True)\n", 
         "release_dates.head()"
       ], 

--- a/Exercises-5.ipynb
+++ b/Exercises-5.ipynb
@@ -80,7 +80,7 @@
       "execution_count": 3, 
       "cell_type": "code", 
       "source": [
-        "cast = pd.read_csv('data/cast.csv')\n", 
+        "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n", 
         "cast.head()"
       ], 
       "outputs": [
@@ -179,7 +179,7 @@
       "execution_count": 4, 
       "cell_type": "code", 
       "source": [
-        "release_dates = pd.read_csv('data/release_dates.csv', \n", 
+        "release_dates = pd.DataFrame.from_csv('data/release_dates.csv', index_col=None,\n", 
         "                                      parse_dates=['date'], infer_datetime_format=True)\n", 
         "release_dates.head()"
       ], 

--- a/Solutions-1.ipynb
+++ b/Solutions-1.ipynb
@@ -138,7 +138,7 @@
     }
    ],
    "source": [
-    "titles = pd.read_csv('data/titles.csv')\n",
+    "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n",
     "titles.head()"
    ]
   },
@@ -230,7 +230,7 @@
     }
    ],
    "source": [
-    "cast = pd.read_csv('data/cast.csv')\n",
+    "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n",
     "cast.head()"
    ]
   },

--- a/Solutions-1.ipynb
+++ b/Solutions-1.ipynb
@@ -138,7 +138,7 @@
     }
    ],
    "source": [
-    "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n",
+    "titles = pd.read_csv('data/titles.csv')\n",
     "titles.head()"
    ]
   },
@@ -230,7 +230,7 @@
     }
    ],
    "source": [
-    "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n",
+    "cast = pd.read_csv('data/cast.csv')\n",
     "cast.head()"
    ]
   },

--- a/Solutions-2.ipynb
+++ b/Solutions-2.ipynb
@@ -138,7 +138,7 @@
     }
    ],
    "source": [
-    "titles = pd.read_csv('data/titles.csv')\n",
+    "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n",
     "titles.head()"
    ]
   },
@@ -230,7 +230,7 @@
     }
    ],
    "source": [
-    "cast = pd.read_csv('data/cast.csv')\n",
+    "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n",
     "cast.head()"
    ]
   },

--- a/Solutions-2.ipynb
+++ b/Solutions-2.ipynb
@@ -138,7 +138,7 @@
     }
    ],
    "source": [
-    "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n",
+    "titles = pd.read_csv('data/titles.csv')\n",
     "titles.head()"
    ]
   },
@@ -230,7 +230,7 @@
     }
    ],
    "source": [
-    "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n",
+    "cast = pd.read_csv('data/cast.csv')\n",
     "cast.head()"
    ]
   },

--- a/Solutions-3.ipynb
+++ b/Solutions-3.ipynb
@@ -138,7 +138,7 @@
     }
    ],
    "source": [
-    "titles = pd.read_csv('data/titles.csv')\n",
+    "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n",
     "titles.head()"
    ]
   },
@@ -230,7 +230,7 @@
     }
    ],
    "source": [
-    "cast = pd.read_csv('data/cast.csv')\n",
+    "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n",
     "cast.head()"
    ]
   },

--- a/Solutions-3.ipynb
+++ b/Solutions-3.ipynb
@@ -138,7 +138,7 @@
     }
    ],
    "source": [
-    "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n",
+    "titles = pd.read_csv('data/titles.csv')\n",
     "titles.head()"
    ]
   },
@@ -230,7 +230,7 @@
     }
    ],
    "source": [
-    "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n",
+    "cast = pd.read_csv('data/cast.csv')\n",
     "cast.head()"
    ]
   },

--- a/Solutions-4.ipynb
+++ b/Solutions-4.ipynb
@@ -138,7 +138,7 @@
     }
    ],
    "source": [
-    "titles = pd.read_csv('data/titles.csv')\n",
+    "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n",
     "titles.head()"
    ]
   },
@@ -230,7 +230,7 @@
     }
    ],
    "source": [
-    "cast = pd.read_csv('data/cast.csv')\n",
+    "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n",
     "cast.head()"
    ]
   },

--- a/Solutions-4.ipynb
+++ b/Solutions-4.ipynb
@@ -138,7 +138,7 @@
     }
    ],
    "source": [
-    "titles = pd.DataFrame.from_csv('data/titles.csv', index_col=None)\n",
+    "titles = pd.read_csv('data/titles.csv')\n",
     "titles.head()"
    ]
   },
@@ -230,7 +230,7 @@
     }
    ],
    "source": [
-    "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n",
+    "cast = pd.read_csv('data/cast.csv')\n",
     "cast.head()"
    ]
   },

--- a/Solutions-5.ipynb
+++ b/Solutions-5.ipynb
@@ -162,7 +162,7 @@
     }
    ],
    "source": [
-    "cast = pd.read_csv('data/cast.csv')\n",
+    "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n",
     "cast.head()"
    ]
   },
@@ -242,7 +242,7 @@
     }
    ],
    "source": [
-    "release_dates = pd.read_csv('data/release_dates.csv', \n",
+    "release_dates = pd.DataFrame.from_csv('data/release_dates.csv', index_col=None,\n",
     "                                      parse_dates=['date'], infer_datetime_format=True)\n",
     "release_dates.head()"
    ]

--- a/Solutions-5.ipynb
+++ b/Solutions-5.ipynb
@@ -162,7 +162,7 @@
     }
    ],
    "source": [
-    "cast = pd.DataFrame.from_csv('data/cast.csv', index_col=None)\n",
+    "cast = pd.read_csv('data/cast.csv')\n",
     "cast.head()"
    ]
   },
@@ -242,7 +242,7 @@
     }
    ],
    "source": [
-    "release_dates = pd.DataFrame.from_csv('data/release_dates.csv', index_col=None,\n",
+    "release_dates = pd.read_csv('data/release_dates.csv', \n",
     "                                      parse_dates=['date'], infer_datetime_format=True)\n",
     "release_dates.head()"
    ]


### PR DESCRIPTION
classmethod DataFrame.from_csv is deprecated since version 0.21.0: Use pandas.read_csv() instead.

A pd.DataFrame.from_csv(path) can be replaced by pd.read_csv(path, index_col=0, parse_dates=True).