### PR TITLE
replacement of order() by sort_values()

### DIFF
--- a/Solutions-3.ipynb
+++ b/Solutions-3.ipynb
@@ -534,7 +534,7 @@
     "c = cast\n",
     "c = c[c.name == 'Frank Oz']\n",
     "g = c.groupby(['character']).size()\n",
-    "g[g > 1].order()"
+    "g[g > 1].sort_values()"
    ]
   },
   {


### PR DESCRIPTION
I noticed, that the pandas.Series.order is not supported in Pandas Version 1.0. A reasonable alternative seems to be sort_values(). 

[release note of pd.series.sort_values()](https://pandas.pydata.org/pandas-docs/version/0.18.0/whatsnew.html)
[pd.series.order() in version 0.18.1](https://pandas.pydata.org/pandas-docs/version/0.18.1/generated/pandas.Series.order.html)
[pd.series.sort_values() in version 1.0](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.sort_values.html)

Thank you for the great tutorial. Your unagitated method of teaching makes this a rather pleasant experience.