### PR TITLE
User jupyter instead of ipython to start notebook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ next section for more detailed instructions):
     $ git clone https://github.com/brandon-rhodes/pycon-pandas-tutorial.git
     $ cd pycon-pandas-tutorial
     $ build/BUILD.sh
-    $ ipython notebook
+    $ jupyter notebook
 
 ## Detailed Instructions
 


### PR DESCRIPTION
The `ipython notebook` command failed but `jupyter notebook` did not. I think this is due to changes since the creation of the video.